### PR TITLE
Fix alternative color options

### DIFF
--- a/hyprland.conf
+++ b/hyprland.conf
@@ -10,14 +10,14 @@ general {
     # non-gradient alternative
     #col.active_border = rgb(bd93f9)
     #col.inactive_border = rgba(44475aaa)
-    #col.group_border = rgba(282a36dd)
-    #col.group_border_active = rgb(bd93f9)
+    #col.nogroup_border = rgba(282a36dd)
+    #col.nogroup_border_active = rgb(bd93f9)
 
     # darker alternative
     #col.active_border = rgb(44475a) # or rgb(6272a4)
     #col.inactive_border = rgb(282a36)
-    #col.group_border = rgb(282a36)
-    #col.group_border_active = rgb(44475a) # or rgb(6272a4)
+    #col.nogroup_border = rgb(282a36)
+    #col.nogroup_border_active = rgb(44475a) # or rgb(6272a4)
 
 }
 decoration {


### PR DESCRIPTION
Seems they incorrect, when I use them Hyprland generate this errors:
```
<general:col.group_border> does not exist.
<general:col.group_border_active> does not exist.
```