### PR TITLE
Fix shadow after hyprland v0.45.0 update

### DIFF
--- a/hyprland.conf
+++ b/hyprland.conf
@@ -20,15 +20,16 @@ general {
     #col.group_border_active = rgb(44475a) # or rgb(6272a4)
 
 }
-decoration {
-    col.shadow = rgba(1E202966)
+
+decoration:shadow {
+    color = rgba(1E202966)
 
     # suggested shadow setting
-    #drop_shadow = yes
-    #shadow_range = 60
-    #shadow_offset = 1 2
-    #shadow_render_power = 3
-    #shadow_scale = 0.97
+    #enabled = true
+    #range = 60
+    #offset = 1 2
+    #render_power = 3
+    #scale = 0.97
 }
 
 group {


### PR DESCRIPTION
In hyprland update v0.45.0 the shadow variables have moved.
This PR moves them to their new place: https://wiki.hyprland.org/Configuring/Variables/#shadow